### PR TITLE
README.md: Remove default shortcuts from table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ CorrectSpelling checks and corrects spelling in various languages.
 
 ## Supported languages
 
-| Code    | Language | Default Shortcut |
-|:-------:|:----------:|:----------------:|
-| **en**  | English | ⌥⌥ (Double press Option key)
-| **de**  | German  | -
-| **es**  | Spanish | -
-| **fr**  | French  | -
-| **pt**  | Portuguese | -
-| **ru**  | Russian | -
+| Code    | Language |
+|:-------:|:----------:|
+| **en**  | English |
+| **de**  | German  |
+| **es**  | Spanish |
+| **fr**  | French  |
+| **pt**  | Portuguese |
+| **ru**  | Russian |
 
 
 ## How to use it


### PR DESCRIPTION
It’s not possible to have default shortcuts because Alfred strips them. Anyone installing the Workflow will have empty hotkeys.